### PR TITLE
We don't need a placeholder anymore.

### DIFF
--- a/vdt/setup/configure_gip
+++ b/vdt/setup/configure_gip
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# configure_gip: formerly read in gip-attributes.conf and created static ldif files.  This
-# functionality is now handled with the dynamic GIP scripts which read the config.ini file.
-# This file is left as a placeholder for scripts which still attempt to execute configure_gip.


### PR DESCRIPTION
The configure_gip script was a placeholder for many years, and most definitely dead for RPMs.  Let's nuke it from future releases.
